### PR TITLE
Optimize lexer

### DIFF
--- a/Tokenizer.js
+++ b/Tokenizer.js
@@ -59,6 +59,11 @@ function parseParameter(tokens) {
         prefix = '...';
         tokens = tokens.shift();
     }
+    if(check(tokens,'rightParen') && identifiers.size > 0) {
+        // No identifiers, list of types
+        const type = '('+identifiers.join(',')+')';
+        return [tokens, [List(), type]];
+    }
     let type;
     [tokens, type] = parseType(tokens);
     return [tokens, [identifiers, prefix+type]];


### PR DESCRIPTION
By making use of the regex /y flag the
tokenization can be performed without using substring over
and over again. This should increase perfomance of lexing,
no metrics have been measured however.

Make parsing of type recursive in order to handle cases
such as `[]*Node` where we need to add both slice and pointer
to the type.