### PR TITLE
Spider download

### DIFF
--- a/ElasticSearchQuery.js
+++ b/ElasticSearchQuery.js
@@ -219,8 +219,10 @@ if(ADD) {
             "name_parts" : ["param", "test"],
             "parameters" : [["x", "int"]],
             "parameters_info" : [{"type" : "int", "count" : 1}],
+            "parameters_count" : 1,
             "result" : [["var", "void"]],
             "result_info" : [{"type":"void","count":1}],
+            "result_count" : 1,
             "uri" : "https:\/\/api.github.com\/paramTest1",
             "votes" : 4
         }
@@ -237,8 +239,10 @@ if(ADD) {
             "name_parts" : ["param", "test"],
             "parameters" : [["x", "int"], ["y", "int"]],
             "parameters_info" : [{"type" : "int", "count" : 2}],
+            "parameters_count" : 2,
             "result" : [["var", "void"]],
             "result_info" : [{"type":"void","count":1}],
+            "result_count" : 1,
             "uri" : "https:\/\/api.github.com\/paramTest2",
             "votes" : 4
         }
@@ -255,8 +259,10 @@ if(ADD) {
             "name_parts" : ["param", "test"],
             "parameters" : [["x", "int"], ["y", "int"], ["z", "int"]],
             "parameters_info" : [{"type" : "int", "count" : 3}],
+            "parameters_count" : 3,
             "result" : [["var", "void"]],
             "result_info" : [{"type":"void","count":1}],
+            "result_count" : 1,
             "uri" : "https:\/\/api.github.com\/paramTest3",
             "votes" : 4
         }
@@ -271,12 +277,15 @@ if(ADD) {
         body: {
             "object": [["s", "SortService"]],
             "object_info" : [{"type":"SortService","count":1}],
+            "object_count" : 1,
             "name" : "paramTest4",
             "name_parts" : ["param", "test"],
             "parameters" : [["x", "int"], ["y","int"] ["s", "String"]],
             "parameters_info" : [{"type":"int","count":2},{"type":"String","count":1}],
+            "parameters_count" : 3,
             "result" : [["var", "void"]],
             "result_info" : [{"type":"void","count":1}],
+            "result_count" : 1,
             "uri" : "https:\/\/api.github.com\/paramTest4",
             "votes" : 4
         }

--- a/ElasticSearchQuery.js
+++ b/ElasticSearchQuery.js
@@ -11,8 +11,8 @@ var client = new elasticsearch.Client({
 
 const DELETE = false;
 const SEARCH = false;
-const ADD = true;
-const CREATE = false;
+const ADD = false;
+const CREATE = true;
 
 if(CREATE) {
     client.indices.create({

--- a/ElasticSearchQuery.js
+++ b/ElasticSearchQuery.js
@@ -16,7 +16,18 @@ const ADD = false;
 if(ADD) {
 	// Create index
 	client.indices.create({
-		index: 'gosearchindex'
+		index: 'gosearchindex',
+        body: {
+		    mappings: {
+                function: {
+                    properties: {
+                        parameters_info: {
+                            type: "nested"
+                        }
+                    }
+                }
+            }
+        }
 	},function(err,resp,status) {
 		if(err) {
 			console.log(err);
@@ -26,7 +37,7 @@ if(ADD) {
 		}
 	});
 
-	// Add documents to index
+/*	// Add documents to index
 	client.index({
 		index: 'gosearchindex',
 		id: '1',
@@ -192,6 +203,80 @@ if(ADD) {
             "parameters_info" : {"__sz" : 3, "int" : 2, "String" : 1},
             "result" : [["var", "void"]],
             "result_info" : {"__sz" : 1, "void" : 1},
+            "uri" : "https:\/\/api.github.com\/paramTest4",
+            "votes" : 4
+        }
+    },function(err,resp,status) {
+        console.log(resp);
+    });*/
+
+    client.index({
+        index: 'gosearchindex',
+        id: '6',
+        type: 'function',
+        body: {
+            "name" : "paramTest1",
+            "name_parts" : ["param", "test"],
+            "parameters" : [["x", "int"]],
+            "parameters_info" : [{"type" : "int", "count" : 1}],
+            "result" : [["var", "void"]],
+            "result_info" : [{"type":"void","count":1}],
+            "uri" : "https:\/\/api.github.com\/paramTest1",
+            "votes" : 4
+        }
+    },function(err,resp,status) {
+        console.log(resp);
+    });
+
+    client.index({
+        index: 'gosearchindex',
+        id: '7',
+        type: 'function',
+        body: {
+            "name" : "paramTest2",
+            "name_parts" : ["param", "test"],
+            "parameters" : [["x", "int"], ["y", "int"]],
+            "parameters_info" : [{"type" : "int", "count" : 2}],
+            "result" : [["var", "void"]],
+            "result_info" : [{"type":"void","count":1}],
+            "uri" : "https:\/\/api.github.com\/paramTest2",
+            "votes" : 4
+        }
+    },function(err,resp,status) {
+        console.log(resp);
+    });
+
+    client.index({
+        index: 'gosearchindex',
+        id: '8',
+        type: 'function',
+        body: {
+            "name" : "paramTest3",
+            "name_parts" : ["param", "test"],
+            "parameters" : [["x", "int"], ["y", "int"], ["z", "int"]],
+            "parameters_info" : [{"type" : "int", "count" : 3}],
+            "result" : [["var", "void"]],
+            "result_info" : [{"type":"void","count":1}],
+            "uri" : "https:\/\/api.github.com\/paramTest3",
+            "votes" : 4
+        }
+    },function(err,resp,status) {
+        console.log(resp);
+    });
+
+    client.index({
+        index: 'gosearchindex',
+        id: '9',
+        type: 'function',
+        body: {
+            "object": [["s", "SortService"]],
+            "object_info" : [{"type":"SortService","count":1}],
+            "name" : "paramTest4",
+            "name_parts" : ["param", "test"],
+            "parameters" : [["x", "int"], ["y","int"] ["s", "String"]],
+            "parameters_info" : [{"type":"int","count":2},{"type":"String","count":1}],
+            "result" : [["var", "void"]],
+            "result_info" : [{"type":"void","count":1}],
             "uri" : "https:\/\/api.github.com\/paramTest4",
             "votes" : 4
         }

--- a/ElasticSearchQuery.js
+++ b/ElasticSearchQuery.js
@@ -9,207 +9,47 @@ var client = new elasticsearch.Client({
     log: 'trace'
 });
 
-const DELETE = true;
+const DELETE = false;
 const SEARCH = false;
-const ADD = false;
+const ADD = true;
+const CREATE = false;
 
-if(ADD) {
-	// Create index
-	client.indices.create({
-		index: 'gosearchindex',
+if(CREATE) {
+    client.indices.create({
+        index: 'gosearchindex',
         body: {
-		    mappings: {
+            mappings: {
                 function: {
                     properties: {
-                        parameters_info: {
-                            type: "nested"
+                        "result_info": {
+                            properties: {
+                                types: {type: "nested"},
+                                total: {type: "integer"}
+                            },
+                            type: "object"
+                        },
+                        "parameters_info": {
+                            properties: {
+                                types: {type: "nested"},
+                                total: {type: "integer"}
+                            },
+                            type: "object"
                         }
                     }
                 }
             }
         }
-	},function(err,resp,status) {
-		if(err) {
-			console.log(err);
-		}
-		else {
-			console.log("create",resp);
-		}
-	});
-
-/*	// Add documents to index
-	client.index({
-		index: 'gosearchindex',
-		id: '1',
-		type: 'function',
-		body: {
-			"object": [["s", "SortService"]],
-			"object_info" : {"__sz" : 1, "SortService" : 1},
-			"name" : "quickSort1",
-			"name_parts" : ["quick", "sort", "1"],
-			"parameters" : [["x", "int"], ["y", "int"]],
-			"parameters_info" : {"__sz" : 2, "int" : 2},
-			"result" : [["first", "int"], ["second", "int"]],
-			"result_info" : {"__sz" : 2, "int" : 2},
-			"uri" : "https:\/\/api.github.com\/quickSort",
-			"votes" : 7
-		}
-	},function(err,resp,status) {
-		console.log(resp);
-	});
-
-	client.index({
-		index: 'gosearchindex',
-		id: '2',
-		type: 'function',
-		body: {
-			"object": [["s", "SortService"]],
-			"object_info" : {"__sz": 1, "SortService" : 1},
-			"name" : "bogoSort",
-			"name_parts" : ["bogo", "sort"],
-			"parameters" : [["x", "int"], ["y", "int"]],
-			"parameters_info" : {"__sz": 2, "int" : 2},
-			"result" : [["first", "int"], ["second", "int"]],
-			"result_info" : {"__sz": 2, "int" : 2},
-			"uri" : "https:\/\/api.github.com\/bogoSort",
-			"votes" : 1
-		}
-	},function(err,resp,status) {
-		console.log(resp);
-	});
-
-	client.index({
-		index: 'gosearchindex',
-		id: '3',
-		type: 'function',
-		body: {
-			"object": [["s", "SortService"]],
-			"object_info" : {"__sz": 1, "SortService" : 1},
-			"name" : "quickSort2",
-			"name_parts" : ["quick", "sort", "2"],
-			"parameters" : [["x", "int"], ["y", "int"], ["z", "int"]],
-			"parameters_info" : {"__sz": 3, "int" : 3},
-			"result" : [["first", "int"], ["second", "int"], [["third", "int"]]],
-			"result_info" : {"__sz" : 3, "int" : 3},
-			"uri" : "https:\/\/api.github.com\/quickSort",
-			"votes" : 5
-		}
-	},function(err,resp,status) {
-		console.log(resp);
-	});
-
-	client.index({
-		index: 'gosearchindex',
-		id: '4',
-		type: 'function',
-		body: {
-			"object": [["s", "SortService"]],
-			"object_info" : {"__sz" : 1, "SortService" : 1},
-			"name" : "wordSort",
-			"name_parts" : ["word", "sort"],
-			"parameters" : [["x", "String"], ["y", "String"]],
-			"parameters_info" : {"__sz" : 2, "String" : 2},
-			"result" : [["first", "String"], ["second", "String"]],
-			"result_info" : {"__sz" : 2, "String" : "2"},
-			"uri" : "https:\/\/api.github.com\/wordSort",
-			"votes" : 3
-		}
-	},function(err,resp,status) {
-		console.log(resp);
-	});
-
-	client.index({
-		index: 'gosearchindex',
-		id: '5',
-		type: 'function',
-		body: {
-			"object": [["s", "SortService"]],
-			"object_info" : {"__sz" : 1, "SortService" : 1},
-			"name" : "mixedSort",
-			"name_parts" : ["mixed", "sort"],
-			"parameters" : [["x", "int"], ["y", "int"], ["z", "String"]],
-			"parameters_info" : {"__sz" : 3, "int" : 2, "String" : 1},
-			"result" : [["first", "object"], ["second", "object"], ["third", "object"]],
-			"result_info" : {"__sz" : 3, "object" : 3},
-			"uri" : "https:\/\/api.github.com\/mixedSort",
-			"votes" : 4
-		}
-	},function(err,resp,status) {
-		console.log(resp);
-	});
-
-    client.index({
-        index: 'gosearchindex',
-        id: '6',
-        type: 'function',
-        body: {
-            "name" : "paramTest1",
-            "name_parts" : ["param", "test"],
-            "parameters" : [["x", "int"]],
-            "parameters_info" : {"__sz" : 1, "int" : 1},
-            "result" : [["var", "void"]],
-            "result_info" : {"__sz" : 1, "void" : 1},
-            "uri" : "https:\/\/api.github.com\/paramTest1",
-            "votes" : 4
-        }
     },function(err,resp,status) {
-        console.log(resp);
+        if(err) {
+            console.log(err);
+        }
+        else {
+            console.log("create",resp);
+        }
     });
+}
 
-    client.index({
-        index: 'gosearchindex',
-        id: '7',
-        type: 'function',
-        body: {
-            "name" : "paramTest2",
-            "name_parts" : ["param", "test"],
-            "parameters" : [["x", "int"], ["y", "int"]],
-            "parameters_info" : {"__sz" : 2, "int" : 2},
-            "result" : [["var", "void"]],
-            "result_info" : {"__sz" : 1, "void" : 1},
-            "uri" : "https:\/\/api.github.com\/paramTest2",
-            "votes" : 4
-        }
-    },function(err,resp,status) {
-        console.log(resp);
-    });
-
-    client.index({
-        index: 'gosearchindex',
-        id: '8',
-        type: 'function',
-        body: {
-            "name" : "paramTest3",
-            "name_parts" : ["param", "test"],
-            "parameters" : [["x", "int"], ["y", "int"], ["z", "int"]],
-            "parameters_info" : {"__sz" : 3, "int" : 3},
-            "result" : [["var", "void"]],
-            "result_info" : {"__sz" : 1, "void" : 1},
-            "uri" : "https:\/\/api.github.com\/paramTest3",
-            "votes" : 4
-        }
-    },function(err,resp,status) {
-        console.log(resp);
-    });
-
-    client.index({
-        index: 'gosearchindex',
-        id: '9',
-        type: 'function',
-        body: {
-            "name" : "paramTest4",
-            "name_parts" : ["param", "test"],
-            "parameters" : [["x", "int"], ["y", "int"], ["z", "String"]],
-            "parameters_info" : {"__sz" : 3, "int" : 2, "String" : 1},
-            "result" : [["var", "void"]],
-            "result_info" : {"__sz" : 1, "void" : 1},
-            "uri" : "https:\/\/api.github.com\/paramTest4",
-            "votes" : 4
-        }
-    },function(err,resp,status) {
-        console.log(resp);
-    });*/
-
+if(ADD) {
     client.index({
         index: 'gosearchindex',
         id: '6',
@@ -273,7 +113,7 @@ if(ADD) {
             "object_info" : {types: [{"type":"SortService","count":1}], total: 1},
             "name" : "paramTest4",
             "name_parts" : ["param", "test"],
-            "parameters" : [["x", "int"], ["y","int"] ["s", "String"]],
+            "parameters" : [["x", "int"], ["y","int"], ["s", "String"]],
             "parameters_info" : {types: [{"type":"int","count":2},{"type":"String","count":1}], total: 3},
             "result" : [["var", "void"]],
             "result_info" : {types: [{"type":"void","count":1}], total: 1},

--- a/ElasticSearchQuery.js
+++ b/ElasticSearchQuery.js
@@ -218,11 +218,9 @@ if(ADD) {
             "name" : "paramTest1",
             "name_parts" : ["param", "test"],
             "parameters" : [["x", "int"]],
-            "parameters_info" : [{"type" : "int", "count" : 1}],
-            "parameters_count" : 1,
+            "parameters_info" : {types: [{"type" : "int", "count" : 1}], total: 1},
             "result" : [["var", "void"]],
-            "result_info" : [{"type":"void","count":1}],
-            "result_count" : 1,
+            "result_info" : {types: [{"type":"void","count":1}], total: 1},
             "uri" : "https:\/\/api.github.com\/paramTest1",
             "votes" : 4
         }
@@ -238,11 +236,9 @@ if(ADD) {
             "name" : "paramTest2",
             "name_parts" : ["param", "test"],
             "parameters" : [["x", "int"], ["y", "int"]],
-            "parameters_info" : [{"type" : "int", "count" : 2}],
-            "parameters_count" : 2,
+            "parameters_info" : {types: [{"type" : "int", "count" : 2}], total: 2},
             "result" : [["var", "void"]],
-            "result_info" : [{"type":"void","count":1}],
-            "result_count" : 1,
+            "result_info" : {types: [{"type":"void","count":1}], total: 1},
             "uri" : "https:\/\/api.github.com\/paramTest2",
             "votes" : 4
         }
@@ -258,11 +254,9 @@ if(ADD) {
             "name" : "paramTest3",
             "name_parts" : ["param", "test"],
             "parameters" : [["x", "int"], ["y", "int"], ["z", "int"]],
-            "parameters_info" : [{"type" : "int", "count" : 3}],
-            "parameters_count" : 3,
+            "parameters_info" : {types: [{"type" : "int", "count" : 3}], total: 3},
             "result" : [["var", "void"]],
-            "result_info" : [{"type":"void","count":1}],
-            "result_count" : 1,
+            "result_info" : {types: [{"type":"void","count":1}], total: 1},
             "uri" : "https:\/\/api.github.com\/paramTest3",
             "votes" : 4
         }
@@ -276,16 +270,13 @@ if(ADD) {
         type: 'function',
         body: {
             "object": [["s", "SortService"]],
-            "object_info" : [{"type":"SortService","count":1}],
-            "object_count" : 1,
+            "object_info" : {types: [{"type":"SortService","count":1}], total: 1},
             "name" : "paramTest4",
             "name_parts" : ["param", "test"],
             "parameters" : [["x", "int"], ["y","int"] ["s", "String"]],
-            "parameters_info" : [{"type":"int","count":2},{"type":"String","count":1}],
-            "parameters_count" : 3,
+            "parameters_info" : {types: [{"type":"int","count":2},{"type":"String","count":1}], total: 3},
             "result" : [["var", "void"]],
-            "result_info" : [{"type":"void","count":1}],
-            "result_count" : 1,
+            "result_info" : {types: [{"type":"void","count":1}], total: 1},
             "uri" : "https:\/\/api.github.com\/paramTest4",
             "votes" : 4
         }

--- a/ElasticSearchQuery.js
+++ b/ElasticSearchQuery.js
@@ -33,16 +33,41 @@ const doCreate = () => {
                 mappings: {
                     function: {
                         properties: {
+                            "object_info": {
+                                properties: {
+                                    types: {
+                                        type: "nested",
+                                        properties: {
+                                            type: { type: "keyword" },
+                                            count: { type: "integer"},
+                                        }
+                                    },
+                                    total: {type: "integer"}
+                                },
+                                type: "object"
+                            },
                             "result_info": {
                                 properties: {
-                                    types: {type: "nested"},
+                                    types: {
+                                        type: "nested",
+                                        properties: {
+                                            type: { type: "keyword" },
+                                            count: { type: "integer"},
+                                        }
+                                    },
                                     total: {type: "integer"}
                                 },
                                 type: "object"
                             },
                             "parameters_info": {
                                 properties: {
-                                    types: {type: "nested"},
+                                    types: {
+                                        type: "nested",
+                                        properties: {
+                                            type: { type: "keyword" },
+                                            count: { type: "integer"},
+                                        }
+                                    },
                                     total: {type: "integer"}
                                 },
                                 type: "object"

--- a/ElasticSearchQuery.js
+++ b/ElasticSearchQuery.js
@@ -9,207 +9,125 @@ var client = new elasticsearch.Client({
     log: 'trace'
 });
 
-const DELETE = false;
-const SEARCH = false;
-const ADD = false;
+const DELETE = true
 const CREATE = true;
+const ADD = false;
 
-if(CREATE) {
-    client.indices.create({
-        index: 'gosearchindex',
-        body: {
-            mappings: {
-                function: {
-                    properties: {
-                        "result_info": {
-                            properties: {
-                                types: {type: "nested"},
-                                total: {type: "integer"}
+const doDelete = () => {
+    return new Promise((resolve, reject) => {
+        client.indices.delete({index: 'gosearchindex'},function(err,resp,status) {
+            if(err) {
+                reject(err);
+            } else {
+                resolve(resp);
+            }
+        });
+    });
+}
+
+const doCreate = () => {
+    return new Promise((resolve, reject) => {
+        client.indices.create({
+            index: 'gosearchindex',
+            body: {
+                mappings: {
+                    function: {
+                        properties: {
+                            "result_info": {
+                                properties: {
+                                    types: {type: "nested"},
+                                    total: {type: "integer"}
+                                },
+                                type: "object"
                             },
-                            type: "object"
-                        },
-                        "parameters_info": {
-                            properties: {
-                                types: {type: "nested"},
-                                total: {type: "integer"}
-                            },
-                            type: "object"
+                            "parameters_info": {
+                                properties: {
+                                    types: {type: "nested"},
+                                    total: {type: "integer"}
+                                },
+                                type: "object"
+                            }
                         }
                     }
                 }
             }
-        }
-    },function(err,resp,status) {
-        if(err) {
-            console.log(err);
-        }
-        else {
-            console.log("create",resp);
-        }
+        },function(err,resp,status) {
+            if(err) {
+                reject(err);
+            }
+            else {
+                resolve(resp);
+            }
+        });
     });
 }
 
-if(ADD) {
-    client.index({
-        index: 'gosearchindex',
-        id: '6',
-        type: 'function',
-        body: {
-            "name" : "paramTest1",
-            "name_parts" : ["param", "test"],
-            "parameters" : [["x", "int"]],
-            "parameters_info" : {types: [{"type" : "int", "count" : 1}], total: 1},
-            "result" : [["var", "void"]],
-            "result_info" : {types: [{"type":"void","count":1}], total: 1},
-            "uri" : "https:\/\/api.github.com\/paramTest1",
-            "votes" : 4
-        }
-    },function(err,resp,status) {
-        console.log(resp);
-    });
+const doAdd = () => {
 
-    client.index({
-        index: 'gosearchindex',
-        id: '7',
-        type: 'function',
-        body: {
-            "name" : "paramTest2",
-            "name_parts" : ["param", "test"],
-            "parameters" : [["x", "int"], ["y", "int"]],
-            "parameters_info" : {types: [{"type" : "int", "count" : 2}], total: 2},
-            "result" : [["var", "void"]],
-            "result_info" : {types: [{"type":"void","count":1}], total: 1},
-            "uri" : "https:\/\/api.github.com\/paramTest2",
-            "votes" : 4
-        }
-    },function(err,resp,status) {
-        console.log(resp);
-    });
+    const addOne = (body) => {
+        return new Promise((resolve, reject) => {
+            client.index({
+                index: 'gosearchindex',
+                type: 'function',
+                body: body,
+            },function(err,resp,status) {
+                if(err) {
+                    reject(err);
+                } else {
+                    resolve(resp);
+                }
+            });
+        });
+    }
 
-    client.index({
-        index: 'gosearchindex',
-        id: '8',
-        type: 'function',
-        body: {
-            "name" : "paramTest3",
-            "name_parts" : ["param", "test"],
-            "parameters" : [["x", "int"], ["y", "int"], ["z", "int"]],
-            "parameters_info" : {types: [{"type" : "int", "count" : 3}], total: 3},
-            "result" : [["var", "void"]],
-            "result_info" : {types: [{"type":"void","count":1}], total: 1},
-            "uri" : "https:\/\/api.github.com\/paramTest3",
-            "votes" : 4
-        }
-    },function(err,resp,status) {
-        console.log(resp);
-    });
+    const docs = [{
+        "name" : "paramTest1",
+        "name_parts" : ["param", "test"],
+        "parameters" : [["x", "int"]],
+        "parameters_info" : {types: [{"type" : "int", "count" : 1}], total: 1},
+        "result" : [["var", "void"]],
+        "result_info" : {types: [{"type":"void","count":1}], total: 1},
+        "uri" : "https:\/\/api.github.com\/paramTest1",
+        "votes" : 4
+    },{
+        "name" : "paramTest2",
+        "name_parts" : ["param", "test"],
+        "parameters" : [["x", "int"], ["y", "int"]],
+        "parameters_info" : {types: [{"type" : "int", "count" : 2}], total: 2},
+        "result" : [["var", "void"]],
+        "result_info" : {types: [{"type":"void","count":1}], total: 1},
+        "uri" : "https:\/\/api.github.com\/paramTest2",
+        "votes" : 4
+    },{
+        "name" : "paramTest3",
+        "name_parts" : ["param", "test"],
+        "parameters" : [["x", "int"], ["y", "int"], ["z", "int"]],
+        "parameters_info" : {types: [{"type" : "int", "count" : 3}], total: 3},
+        "result" : [["var", "void"]],
+        "result_info" : {types: [{"type":"void","count":1}], total: 1},
+        "uri" : "https:\/\/api.github.com\/paramTest3",
+        "votes" : 4
+    },{
+        "object": [["s", "SortService"]],
+        "object_info" : {types: [{"type":"SortService","count":1}], total: 1},
+        "name" : "paramTest4",
+        "name_parts" : ["param", "test"],
+        "parameters" : [["x", "int"], ["y","int"], ["s", "String"]],
+        "parameters_info" : {types: [{"type":"int","count":2},{"type":"String","count":1}], total: 3},
+        "result" : [["var", "void"]],
+        "result_info" : {types: [{"type":"void","count":1}], total: 1},
+        "uri" : "https:\/\/api.github.com\/paramTest4",
+        "votes" : 4
+    }];
 
-    client.index({
-        index: 'gosearchindex',
-        id: '9',
-        type: 'function',
-        body: {
-            "object": [["s", "SortService"]],
-            "object_info" : {types: [{"type":"SortService","count":1}], total: 1},
-            "name" : "paramTest4",
-            "name_parts" : ["param", "test"],
-            "parameters" : [["x", "int"], ["y","int"], ["s", "String"]],
-            "parameters_info" : {types: [{"type":"int","count":2},{"type":"String","count":1}], total: 3},
-            "result" : [["var", "void"]],
-            "result_info" : {types: [{"type":"void","count":1}], total: 1},
-            "uri" : "https:\/\/api.github.com\/paramTest4",
-            "votes" : 4
-        }
-    },function(err,resp,status) {
-        console.log(resp);
-    });
+    const promises = docs.map(addOne);
+
+    return Promise.all(promises);
 }
 
-// Query index
-/*
-    The script sums up the discrepancies between the query and a doc. Logarithm is used to dampen the effect when
-    large number of parameters are different. This score is inverted in order to get a similarity score. +2 is used
-    to avoid division by 0.
-    Sample cases for parameter matching:
-     - Identical amount of parameters:
-        Query for {int: 1, String: 1} when doc is {int: 1, String: 1}
-        Result: nonmatch = 0, additional = 0, returns 1/log(0+0+2) = 3.3
-     - Different amount of parameters:
-        Query for {int: 2, String: 1} when doc is {int: 1, String: 1}
-        Result: nonmatch = 1, additional = 0, returns 1/log(1+0+2) = 2.1
-     - Query has more parameters than doc:
-        Query for {int: 1, String: 1, float: 1} when doc is {int: 1, String: 1}
-        Result: nonmatch = 1 (increased in catch), additional = 0, returns 1/log(1+0+2) = 2.1
-     - Query has less parameters than doc:
-        Query for {int: 1} when doc is {int: 1, String: 1}
-        Result: nonmatch = 0, additional = 1, returns 1/log(1+0+2) = 2.1
- */
- if(SEARCH) {
-	client.search({
-		index: 'gosearchindex',
-		type: 'function',
-		body: {
-			query: {
-				function_score: {
-					query: {
-						bool: {
-							should: [{
-								terms: {"object": [], boost: 1}
-							}, {
-								match: {"name": {query: "sort", boost: 5}}
-							}, {
-								terms: {"name_parts": ["sort"], boost: 5}
-							}, {
-								terms: {"parameters": ["int", "int"], boost: 2}
-							}, {
-								terms: {"result": ["int"], boost: 2}
-							}]
-						}
-					},
-					functions: [
-						{
-							script_score: {
-								script: {
-									inline: "int nonmatch = 0;" +
-											"int additional = (int) doc['parameters_info.__sz'].value;" +
-                                            "try {" +
-                                            "   nonmatch += (int) Math.abs(doc['parameters_info.int'][0] - 2);" +
-                                            "   additional -= doc['parameters_info.int'][0];" +
-                                            "} catch (Exception e) {" +
-                                            "   nonmatch += 2" +
-                                            "}" +
-											"return 1 / Math.log(nonmatch + additional + 2);"
-								}
-							}
-						},
-						{
-							field_value_factor: {
-								field: "votes",
-								modifier: "log1p"
-							}
-						}
-					]
-				}
-			}
-		}
-	},function (error, response,status) {
-		if (error){
-			console.log("search error: "+error)
-		}
-		else {
-			console.log("--- Response ---");
-			console.log(response);
-			console.log("--- Hits ---");
-			response.hits.hits.forEach(function(hit){
-				console.log(hit);
-			})
-		}
-	});
-}
+const del = DELETE ? doDelete : Promise.resolve.bind(Promise);
+const create = CREATE ? doCreate : Promise.resolve.bind(Promise);
+const add = ADD ? doAdd : Promise.resolve.bind(Promise);
 
-// Delete index
-if(DELETE) {
-	client.indices.delete({index: 'gosearchindex'},function(err,resp,status) {
-		console.log("delete",resp);
-	});
-}
+del().then(create).then(add);
+

--- a/Indexer.js
+++ b/Indexer.js
@@ -4,6 +4,11 @@ const filepath = './files';
 const fspath = require('path');
 const fs = require('fs');
 const elasticsearch = require('elasticsearch');
+// Limit number of concurrently open connections
+const http = require('http');
+const https = require('https');
+http.globalAgent.maxSockets  = 123;
+https.globalAgent.maxSockets = 123;
 const esClient = new elasticsearch.Client({
     host: 'localhost:9200',
     //log: 'trace'

--- a/Tokenizer.js
+++ b/Tokenizer.js
@@ -204,6 +204,7 @@ function parseTokens(tokens) {
         if(PRINTOUTS) console.error('    :: anon function');
         [tokens2, parameters] = parseParameters(tokens);
         parameters_info = getTypeInfo(parameters);
+        console.log(parameters);
         [tokens3, result] = parseResult(tokens2);
         if(PRINTOUTS) console.error("Result: " + result);
         if(PRINTOUTS) console.error(result);
@@ -288,7 +289,7 @@ function getTypeInfo(arr) {
             count: typeCounts[type],
         };
     });
-    const total = Array.from(types).reduce((sum, param) => {
+    const total = types.reduce((sum, param) => {
         return sum + param.count;
     }, 0);
     return {types, total};

--- a/Tokenizer.js
+++ b/Tokenizer.js
@@ -171,7 +171,7 @@ function parseTokens(tokens) {
             object: receiver.toJS(),
             object_info,
             name,
-            name_parts: name_parts.toJS(),
+            name_parts: name_parts,
             parameters: parameters.toJS(),
             parameters_info,
             result: result.toJS(),

--- a/Tokenizer.js
+++ b/Tokenizer.js
@@ -49,6 +49,9 @@ function parseParameterList(tokens) {
 function parseIdentifier(tokens) {
     expect(tokens, 'identifier');
     const identifier = tokens.get(0).text;
+    if(identifier == 'func') {
+        throw new Error('Trying to parse keyword func as identifier');
+    }
     tokens = tokens.shift();
     return [tokens, identifier];
 }
@@ -201,10 +204,10 @@ function parseTokens(tokens) {
     }
     try {
         // trying to see if it is an anonymous function e.g. func (parameters) result
-        if(PRINTOUTS) console.error('    :: anon function');
+        if (PRINTOUTS) console.error('    :: anon function');
         [tokens2, parameters] = parseParameters(tokens);
         parameters_info = getTypeInfo(parameters);
-        console.log(parameters);
+        if (PRINTOUTS) console.log(parameters);
         [tokens3, result] = parseResult(tokens2);
         if(PRINTOUTS) console.error("Result: " + result);
         if(PRINTOUTS) console.error(result);
@@ -313,7 +316,7 @@ function tokenizeStream(stream) {
             if(commentIndex != -1) {
                 line = line.substring(0, commentIndex); // shorten the line up to where the comment begins
             }
-            let index = inMatch ? 0 : line.search(/func .*/);
+            let index = inMatch ? 0 : line.search(/func\W*/);
             inMatch = (index != -1);
             if(!inMatch) { // no function in this line
                 tokens = [];

--- a/Tokenizer.js
+++ b/Tokenizer.js
@@ -340,10 +340,13 @@ function tokenizeStream(stream) {
                         else if (matcher === 'leftBrace') {
                             // found the end of this function declaration
                             if(PRINTOUTS) console.error("Found end of function declaration, parsing ...");
-                            const result = parseTokens(List(tokens));
-                            if(result) {
-                                const parseTree = result[1];
-                                signatures.push(parseTree);
+                            try {
+                                const result = parseTokens(List(tokens));
+                                if(result) {
+                                    const parseTree = result[1];
+                                    signatures.push(parseTree);
+                                }
+                            } catch (e) {
                             }
                             tokens = [];
                             inMatch = false;

--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ var client = new elasticsearch.Client({
     log: 'trace'
 });
 
+
 // Set up view rendering using handlebars templates
 app.use(express.static(__dirname + '/views'));
 app.set('view engine', 'html');
@@ -17,157 +18,166 @@ app.set('view engine', 'hbs');
 
 app.get('/search', function(req, res) {
     const queryString = req.query.q;
-    if(queryString) {
-        let q = queryString;
-        if (!/func/.test(queryString)) {
-            q = 'func ' + q;
+    if(!queryString) {
+        return res.status(400);
+    }
+
+    let q = queryString;
+    if (!/func/.test(queryString)) {
+        q = 'func ' + q;
+    }
+    q = q + '{';
+
+    tokenizeString(q)
+    .then(function (json) {
+        if(!json[0]) {
+            return tokenizeString('func '+queryString+'() {');
         }
-        q = q + '{';
-        tokenizeString(q).then(function (json) {
-            if(!json[0]) {
-                return tokenizeString('func '+queryString+'() {');
-            }
-            return json;
-        }).then(function(json) {
-            const paramTypes = json[0].parameters_info && json[0].parameters_info.types || [];
-            const parameterQueries = paramTypes.map((param) => {
-                return {
-                    nested: {
-                        path: "parameters_info.types",
-                        query: {
-                            function_score: {
-                                query: {
-                                    match: {"parameters_info.types.type": param.type},
-                                },
-                                gauss: {
-                                    "parameters_info.types.count": {
-                                        origin: param.count,
-                                        scale: 1,
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            });
+        return json;
+    })
+    .then(function(json) {
 
-            const resultTypes = json[0].result_info && json[0].result_info.types || [];
-            const resultQueries = resultTypes.map((param) => {
-                return {
-                    nested: {
-                        path: "result_info.types",
-                        query: {
-                            function_score: {
-                                query: {
-                                    match: {"result_info.types.type": param.type},
-                                },
-                                gauss: {
-                                    "result_info.types.count": {
-                                        origin: param.count,
-                                        scale: 1,
-                                    }
-                                }
-                            }
-                        }
-                    }
-                });
-
-            const receiverTypes = json[0].receiver_info && json[0].receiver_info.types || [];
-            const receiverQueries = receiverTypes.map((param) => {
-                return {
-                    nested: {
-                        path: "object_info.types",
-                        query: {
-                            function_score: {
-                                query: {
-                                    match: {"object_info.types.type": param.type},
-                                },
-                                gauss: {
-                                    "object_info.types.count": {
-                                        origin: param.count,
-                                        scale: 1,
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            });
-
-            const query = {
-                index: 'gosearchindex',
-                search_type: 'dfs_query_then_fetch',
-                type: 'function',
-                body: {
+        const paramTypes = json[0].parameters_info && json[0].parameters_info.types || [];
+        const parameterQueries = paramTypes.map((param) => {
+            return {
+                nested: {
+                    path: "parameters_info.types",
                     query: {
                         function_score: {
                             query: {
-                                bool: {
-                                    should: parameterQueries
-                                        .concat(resultQueries)
-                                        .concat(receiverQueries)
-                                        .concat([{
-                                            terms: {
-                                                "name_parts": (json[0].name_parts || []),
-                                                boost: 5
-                                            }
-                                        },
-                                        {
-                                            function_score: {
-                                                gauss: {
-                                                    "parameters_info.total": {
-                                                        origin: (json[0].parameters_info.total || 0),
-                                                        scale: 1,
-                                                    }
-                                                }
-                                            },
-                                            {
-                                                function_score: {
-                                                    gauss: {
-                                                        "result_info.total": {
-                                                            origin: (json[0].result_info.total || 0),
-                                                            scale: 1,
-                                                        }
-                                                    }
-                                                }
-                                            }])
-                                    }
-                                }/*,
-                                functions: [{
-                                    field_value_factor: {
-                                        field: "votes",
-                                        modifier: "log1p"
-                                    }
-                                }]*/
+                                match: {"parameters_info.types.type": param.type},
+                            },
+                            gauss: {
+                                "parameters_info.types.count": {
+                                    origin: param.count,
+                                    scale: 1,
+                                }
                             }
                         }
                     }
                 }
-            };
+            }
+        });
 
-            client.search(query, function (error, response, status) {
-                if (error) {
-                    console.log("search error: " + error)
+        const resultTypes = json[0].result_info && json[0].result_info.types || [];
+        const resultQueries = resultTypes.map((param) => {
+            return {
+                nested: {
+                    path: "result_info.types",
+                    query: {
+                        function_score: {
+                            query: {
+                                match: {"result_info.types.type": param.type},
+                            },
+                            gauss: {
+                                "result_info.types.count": {
+                                    origin: param.count,
+                                    scale: 1,
+                                }
+                            }
+                        }
+                    }
                 }
-                else {
-                    console.log("--- Hits ---");
-                    response.hits.hits.forEach(function (hit) {
-                        console.log(JSON.stringify(hit));
-                    })
-                    res.end(JSON.stringify({results: response.hits.hits.map(hit => hit._source)}));
-                }
-            });
+            }
+        });
 
-            });
-        }
+        const receiverTypes = json[0].receiver_info && json[0].receiver_info.types || [];
+        const receiverQueries = receiverTypes.map((param) => {
+            return {
+                nested: {
+                    path: "object_info.types",
+                    query: {
+                        function_score: {
+                            query: {
+                                match: {"object_info.types.type": param.type},
+                            },
+                            gauss: {
+                                "object_info.types.count": {
+                                    origin: param.count,
+                                    scale: 1,
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        });
+
+
+        const query = {
+            index: 'gosearchindex',
+            search_type: 'dfs_query_then_fetch',
+            type: 'function',
+            body: {
+                query: {
+                    function_score: {
+                        query: {
+                            bool: {
+                                should: parameterQueries
+                                .concat(resultQueries)
+                                .concat(receiverQueries)
+                                .concat([{
+                                    terms: {
+                                        "name_parts": (json[0].name_parts || []),
+                                        boost: 5
+                                    }
+                                },
+                                {
+                                    function_score: {
+                                        gauss: {
+                                            "object_info.total": {
+                                                origin: (json[0].parameters_info.total || 0),
+                                                scale: 1,
+                                            }
+                                        }
+                                    }
+                                },
+                                {
+                                    function_score: {
+                                        gauss: {
+                                            "parameters_info.total": {
+                                                origin: (json[0].parameters_info.total || 0),
+                                                scale: 1,
+                                            }
+                                        }
+                                    }
+                                },
+                                {
+                                    function_score: {
+                                        gauss: {
+                                            "result_info.total": {
+                                                origin: (json[0].result_info.total || 0),
+                                                scale: 1,
+                                            }
+                                        }
+                                    }
+                                }])
+                            } //bool
+                        } //query
+                    } //func score
+                } //query
+            } //body
+        };
+
+        client.search(query, function (error, response, status) {
+            if (error) {
+                console.log("search error: " + error)
+            }
+            else {
+                console.log("--- Hits ---");
+                response.hits.hits.forEach(function (hit) {
+                    console.log(JSON.stringify(hit));
+                })
+                res.end(JSON.stringify({results: response.hits.hits.map(hit => hit._source)}));
+            }
+        });
+    });
 });
 
 // Set up view rendering using handlebars templates
 app.use(express.static(__dirname + '/views'));
 app.set('view engine', 'html');
 app.set('view engine', 'hbs');
-
-});
 
 app.listen(PORT, function () {
     console.log('Example app listening on port ' + PORT)

--- a/index.js
+++ b/index.js
@@ -29,7 +29,6 @@ app.get('/search', function(req, res) {
             }
             return json;
         }).then(function(json) {
-            console.log(json);
             const paramTypes = json[0].parameters_info && json[0].parameters_info.types || [];
             const parameterQueries = paramTypes.map((param) => {
                 return {

--- a/index.js
+++ b/index.js
@@ -95,7 +95,7 @@ app.get('/search', function(req, res) {
         //console.log(scriptString)
 >>>>>>> 367972b... Add score adjustment for total number of parameters
 
-        const parameters = [{type: 'int', count: 1}];
+        const parameters = [{type: 'int', count: 2},{type: 'String', count: 1}];
 
         const parameterQueries = parameters.map(param => {
             return {
@@ -132,9 +132,23 @@ app.get('/search', function(req, res) {
                                         "name_parts": (json[0].name_parts !== undefined ? json[0].name_parts : []),
                                         boost: 5
                                     }
-                                }])
+                                }].concat([{
+                                    nested: {
+                                        path: "parameters_info",
+                                        query: {
+                                            function_score: {
+                                                gauss: {
+                                                    "parameters_info.total": {
+                                                        origin: 3, // TODO insert json[0].parameters_info.total
+                                                        scale: 1,
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }]))
                             }
-                        },
+                        }/*,
                         functions: [{
                             gauss: {
                                 "parameters_info.total": {
@@ -142,7 +156,7 @@ app.get('/search', function(req, res) {
                                     scale: 1,
                                 }
                             }
-                        }]
+                        }]*/
                     }
                 }
             }

--- a/index.js
+++ b/index.js
@@ -104,10 +104,10 @@ app.get('/search', function(req, res) {
                     query: {
                         function_score: {
                             query: {
-                                match: {"parameters_info.type": param.type},
+                                match: {"parameters_info.types.type": param.type},
                             },
                             gauss: {
-                                "parameters_info.count": {
+                                "parameters_info.types.count": {
                                     origin: param.count,
                                     scale: 1,
                                 }
@@ -137,7 +137,7 @@ app.get('/search', function(req, res) {
                         },
                         functions: [{
                             gauss: {
-                                "parameters_count": {
+                                "parameters_info.total": {
                                     origin: 1, // TODO insert json[0].parameters_count
                                     scale: 1,
                                 }

--- a/index.js
+++ b/index.js
@@ -30,7 +30,8 @@ app.get('/search', function(req, res) {
             return json;
         }).then(function(json) {
             console.log(json);
-            const parameterQueries = json[0].parameters_info.types.map((param) => {
+            const paramTypes = json[0].parameters_info && json[0].parameters_info.types || [];
+            const parameterQueries = paramTypes.map((param) => {
                 return {
                     nested: {
                         path: "parameters_info.types",
@@ -51,7 +52,8 @@ app.get('/search', function(req, res) {
                 }
             });
 
-            const resultQueries = json[0].result_info.types.map((param) => {
+            const resultTypes = json[0].result_info && json[0].result_info.types || [];
+            const resultQueries = resultTypes.map((param) => {
                 return {
                     nested: {
                         path: "result_info.types",
@@ -71,7 +73,8 @@ app.get('/search', function(req, res) {
                     }
                 });
 
-            const receiverQueries = json[0].object_info.types.map((param) => {
+            const receiverTypes = json[0].receiver_info && json[0].receiver_info.types || [];
+            const receiverQueries = receiverTypes.map((param) => {
                 return {
                     nested: {
                         path: "object_info.types",

--- a/index.js
+++ b/index.js
@@ -95,7 +95,7 @@ app.get('/search', function(req, res) {
         //console.log(scriptString)
 >>>>>>> 367972b... Add score adjustment for total number of parameters
 
-        const parameters = [{type: 'int', count: 2},{type: 'String', count: 1}];
+        const parameters = [{type: 'int', count: 2},{type: 'String', count: 1}]; // TODO (json[0].parameters_info.types !== undefined ? json[0].parameters_info.types : [])
 
         const parameterQueries = parameters.map(param => {
             return {
@@ -139,7 +139,7 @@ app.get('/search', function(req, res) {
                                             function_score: {
                                                 gauss: {
                                                     "parameters_info.total": {
-                                                        origin: 3, // TODO insert json[0].parameters_info.total
+                                                        origin: 3, // TODO (json[0].parameters_info.total !== undefined ? 0)
                                                         scale: 1,
                                                     }
                                                 }
@@ -148,15 +148,13 @@ app.get('/search', function(req, res) {
                                     }
                                 }]))
                             }
-                        }/*,
+                        },
                         functions: [{
-                            gauss: {
-                                "parameters_info.total": {
-                                    origin: 1, // TODO insert json[0].parameters_count
-                                    scale: 1,
-                                }
-                            }
-                        }]*/
+                            field_value_factor: {
+                                field: "votes",
+                                modifier: "log1p"
+                             }
+                        }]
                     }
                 }
             }

--- a/index.js
+++ b/index.js
@@ -44,109 +44,111 @@ app.get('/search', function(req, res) {
 			var func = JSON.stringify(result)
 			var json = JSON.parse(func)
 
-			var scriptString = "int nonmatch = 0;" +
-				"int additionalObject = (int) doc['object_info.__sz'].value;"
-			for (var key in json[0].object_info) {
-				if (json[0].object_info.hasOwnProperty(key) && key != '__sz') {
-					scriptString +=
-						"try {" +
-						"   nonmatch += (int) Math.abs(doc['object_info." + key + "'][0] - " + json[0].object_info[key] + ");" +
-						"   additionalObject -= doc['object_info." + key + "'][0];" +
-						"} catch (Exception e) {" +
-						"   nonmatch += " + json[0].object_info[key] +
-						"}"
-				}
-			}
-			scriptString += "int additionalParam = (int) doc['parameters_info.__sz'].value;"
-			for (var key in json[0].parameters_info) {
-				if (json[0].parameters_info.hasOwnProperty(key) && key != '__sz') {
-					scriptString +=
-						"try {" +
-						"   nonmatch += (int) Math.abs(doc['parameters_info." + key + "'][0] - " + json[0].parameters_info[key] + ");" +
-						"   additionalParam -= doc['parameters_info." + key + "'][0];" +
-						"} catch (Exception e) {" +
-						"   nonmatch += " + json[0].parameters_info[key] +
-						"}"
-				}
-			}
-			scriptString += "int additionalResult = (int) doc['result_info.__sz'].value;"
-			for (var key in json[0].result_info) {
-				if (json[0].result_info.hasOwnProperty(key) && key != '__sz') {
-					scriptString +=
-						"try {" +
-						"   nonmatch += (int) Math.abs(doc['result_info." + key + "'][0] - " + json[0].result_info[key] + ");" +
-						"   additionalResult -= doc['result_info." + key + "'][0];" +
-						"} catch (Exception e) {" +
-						"   nonmatch += " + json[0].result_info[key] +
-						"}"
-				}
-			}
-			scriptString += "return 1 / Math.log(nonmatch + additionalObject + additionalParam + additionalResult + 2);"
 
-			console.log(scriptString)
+        const parameters = [{type: 'String', count: 1},{type: 'int', count: 1}];
 
-			client.search({
-				index: 'gosearchindex',
-				search_type: 'dfs_query_then_fetch',
-				type: 'function',
-				body: {
-					query: {
-						function_score: {
-							query: {
-								bool: {
-									should: [{
-									//    terms: {"object": (json[0].object !== undefined ? json[0].object[0] : []), boost: 1}
-									//}, {
-									//    match: {"name": {query: (json[0].name !== undefined ? json[0].name : []), boost: 5}}
-									//}, {
-										terms: {"name_parts": (json[0].name_parts !== undefined ? json[0].name_parts : []), boost: 5}
-									//}, {
-									//    terms: {"parameters": (json[0].parameters !== undefined ? json[0].parameters[0] : []), boost: 2}
-									//}, {
-									//    terms: {"result": (json[0].result !== undefined ? json[0].result[0] : []), boost: 2}
-									}]
-								}
-							},
-							functions: [
-								{
-									script_score: {
-										script: {
-											inline: scriptString
-										}
-									}
-								},
-								{
-									field_value_factor: {
-										field: "votes",
-										modifier: "log1p"
-									}
-								}
-							]
-						}
-					}
-				}
-			},function (error, response,status) {
-				if (error){
-					console.log("search error: "+error)
-				}
-				else {
-					console.log("--- Response ---");
-					console.log(response);
-					console.log("--- Hits ---");
-					response.hits.hits.forEach(function(hit){
-						console.log(hit);
-						output.push([hit._score + " " + hit._source.name])
-					})
-				}
-			});
-		})	
-		res.json( { results: output } );
-		}
-		else {
-			res.json(context);
-		}
-	}
+        const parameterQueries = parameters.map(param => {
+            return {
+                nested: {
+                    path: "parameters_info",
+                    query: {
+                        function_score: {
+                            query: {
+                                match: {"parameters_info.type": param.type},
+                            },
+                            gauss: {
+                                "parameters_info.count": {
+                                    origin: param.count,
+                                    scale: 1,
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        });
 
+        const query = {
+            index: 'gosearchindex',
+            search_type: 'dfs_query_then_fetch',
+            type: 'function',
+            body: {
+                query: {
+                    bool: {
+                        should: parameterQueries.concat([{
+                            terms: {"name_parts": (json[0].name_parts !== undefined ? json[0].name_parts : []), boost: 5}
+                        }])
+                    }
+                }
+            }
+        }
+        /*
+        {
+            index: 'gosearchindex',
+                search_type: 'dfs_query_then_fetch',
+            type: 'function',
+            body: {
+            query: {
+                function_score: {
+                    query: {
+                        bool: {
+                            should: parameterQueries/*([ {
+                             //    terms: {"object": (json[0].object !== undefined ? json[0].object[0] : []), boost: 1}
+                             //}, {
+                             //    match: {"name": {query: (json[0].name !== undefined ? json[0].name : []), boost: 5}}
+                             //}, {
+                             //terms: {"name_parts": (json[0].name_parts !== undefined ? json[0].name_parts : []), boost: 5}
+                             //}, {
+                             //    terms: {"parameters": (json[0].parameters !== undefined ? json[0].parameters[0] : []), boost: 2}
+                             //}, {
+                             //    terms: {"result": (json[0].result !== undefined ? json[0].result[0] : []), boost: 2}
+                             }])
+                        }
+                    },
+
+                    //functions: [
+                    /*{
+                     script_score: {
+                     script: {
+                     inline: scriptString
+                     }
+                     }
+                     },
+                    /*{
+                     field_value_factor: {
+                     field: "votes",
+                     modifier: "log1p"
+                     }
+                     }
+
+                    //]
+                }
+            }
+        }
+        }*/
+
+        client.search(query,function (error, response,status) {
+            if (error){
+                console.log("search error: "+error)
+            }
+            else {
+                console.log("--- Response ---");
+                console.log(response);
+                console.log("--- Hits ---");
+                response.hits.hits.forEach(function(hit){
+                    console.log(JSON.stringify(hit));
+                    output.push([hit._score + " " + hit._source.name])
+                })
+            }
+        });
+    })
+
+    res.render('index', {
+        results : [
+            {
+                "arguments": output
+            }]
+    });
 });
 
 app.listen(PORT, function () {

--- a/spider.js
+++ b/spider.js
@@ -14,7 +14,7 @@ const mkdirs = require('node-mkdirs');
 
 const language = 'go';
 const languageFile = '.go';
-const startURL = 'https://api.github.com/search/repositories?q=language:'+language+'&page=34';
+const startURL = 'https://api.github.com/search/repositories?q=language:'+language+'&page=10';
 // WARNING: github has i request limit. 10 per minute if unauthorized and 30 authorized. 
 // For this case there are 34 pages in total, so only fetching the three last for now
 const filesPath = 'files';
@@ -79,7 +79,6 @@ function unzipRepo(zipFile){
  */
 function fetchRepo(repo) {
     return new Promise( function(resolve, reject) {
-
         let url = new URL(repo.url);
         // remove word "repos/" in url with substring
         let fetchURL = 'https://github.com/'+url.pathname.substring(7)+'/archive/master.zip'
@@ -89,23 +88,10 @@ function fetchRepo(repo) {
             // dont download repo if unzipped version already exists
             return resolve();
         }
-        try {
-        wget({
-            url: fetchURL,
-            dest: zipFile,
-            },
-            function(err, data) {
-                if(err){
-                    console.error(err);
-                    return reject(err);
-                }
-                return resolve(zipFile);
-            }
-            );
-        } catch (e) {
-            console.error(e);
-            return resolve();
-        }
+        console.error(fetchURL);
+        request(fetchURL).pipe(fs.createWriteStream(zipFile))
+            .on('error', (err) => resolve())
+            .on('finish', () => resolve(zipFile))
     });
 }
 

--- a/test/parsing.js
+++ b/test/parsing.js
@@ -13,3 +13,7 @@ const sig2 = 'func (Rec r) read(path string, size int) (count, bytes int){'
 const sig3 = 'func fly(int) float {'
 
 tokenizeString(sig3).then(JSON.stringify).then(log);
+
+const sig4 = 'func (r *Response) Write(bytes []byte) (int, error) {';
+
+tokenizeString(sig4).then(JSON.stringify).then(log);

--- a/views/index.html
+++ b/views/index.html
@@ -1,130 +1,125 @@
 <html>
-	<head>
-		<link rel="stylesheet" type="text/css" href="style.css">
-	</head>
-	<body>
-		<img src="goheader.png" id="header">
-		<div id="topDiv" style="">
-			<div id="upper">
-				<input type="text" id="searchField" name="search">
-			</div>
-			<div id="lower">
-				<button id="searchButton">Go search!</button>
-			</div>
-		</div>
-		
-		<div id="results">
-			<div>
-				<p>1. read(x int, y double, str string, ) string</p>
-				<a href="www.github.com">www.github.com/yadayadayad/yadayadyada</a>
-			</div>
-			<div>
-				<p>2. write(offset int, length double, )</p>
-				<a href="www.github.com">www.github.com/yadayadayad/yadayadyada</a>
-			</div>
-		</div>
-		
-		<div id="footer">
-			A project for DH2642<br>&copy 2017
-		</div>
-		<script>
-			var searchContent = ""; // last search string
-			var results = []; // search results
-			
-			// grabs the text from the search field and performs a search if necessary and then stages the results
-			function loadResults() {
-				var newSearch = document.getElementById("searchField").value;
-				if(newSearch != searchContent) {
-					searchContent = newSearch;
-					if(newSearch != "") {
-						var xhttp = new XMLHttpRequest();
-						xhttp.onreadystatechange = function() {
-							if (this.readyState == 4 && this.status == 200) {
-								// Typical action to be performed when the document is ready:
-								console.log(xhttp.responseText);
-								results = JSON.parse(xhttp.responseText).results;
-								setContent();
-							}
-						};
-						//xhttp.open("GET", "http://search.considerate.se/?q=" + newSearch, true);
-						xhttp.open("GET", "http://localhost:3000/search?q=" + newSearch, true);
-						xhttp.send();
-					}
-					else {
-						results = [];
-						setContent();
-					}
-				}
-			}
-			
-			function getResultBlock(resultNo, name, objects, parameters, returns, link) {
-				string = "";
-				if(objects.length > 0) {
-					string += "(";
-					for(var i = 0; i < objects.length; ++i) {
-						if(i > 0) string += ", ";
-						string += objects[i][0] + " ";
-						string += objects[i][1];
-					}
-					string += ") ";
-				}
-				string += name;
-				string += "(";
-				if(parameters.length > 0) {
-					for(var i = 0; i < parameters.length; ++i) {
-						if(i > 0) string += ", ";
-						string += parameters[i][0] + " ";
-						string += parameters[i][1];
-					}	
-				}
-				string += ") ";
-				if(returns.length > 0) {
-					string += "(";
-					for(var i = 0; i < returns.length; ++i) {
-						if(i > 0) string += ", ";
-						string += returns[i][0] + " ";
-						string += returns[i][1];
-					}
-					string += ") ";
-				}
-				return '<div><p>' + resultNo + '. ' + string + '</p><a href="' + link + '">' + link + '</a></div>';
-			}
-			
-			// sets the contents of the search results, if any query has been entered
-			function setContent() {
-				if(searchContent != "") {
-					document.getElementById("results").innerHTML = "";
-					res = "";
-					console.log(results);
-					for(var i = 0; i < results.length; ++i) {
-						res += getResultBlock(i, results[i].name || '', results[i].object || [], results[i].parameters || [], results[i].result || [], results[i].uri || '');
-					}
-					document.getElementById("results").innerHTML = res;
-					document.getElementById("results").style.display = "block";
-					if(results.length === 0) document.getElementById("results").innerHTML = '<p id="error">NO results, please try again...</p>';
-					
-				}
-				else document.getElementById("results").style.display = "none";
-			}
-			
-			// catch enter keys from search field and click button if one occurs
-			function enterKey(event) { 
-				event.preventDefault();
-				if (event.keyCode == 13) {
-					document.getElementById("searchButton").click();
-					document.getElementById("searchField").blur();
-				}
-			}
-			
-			setContent();
-			document.getElementById("searchButton").addEventListener('click', loadResults);
-			document.getElementById("searchButton").addEventListener('mouseover', function() { this.style.backgroundColor = "#13626c"; });
-			document.getElementById("searchButton").addEventListener('mouseout', function() { this.style.backgroundColor = "#a8e7f0"; });
-			document.getElementById("searchButton").addEventListener('mousedown', function() { this.style.backgroundColor = "black"; });
-			document.getElementById("searchButton").addEventListener('mouseup', function() { this.style.backgroundColor = "#13626c"; });
-			document.getElementById("searchField").addEventListener("keyup", enterKey);
-		</script>
-	</body>
-	
+    <head>
+        <link rel="stylesheet" type="text/css" href="style.css">
+    </head>
+    <body>
+        <img src="goheader.png" id="header" alt="gopher"/>
+        <div id="topDiv" style="">
+            <div id="upper">
+                <input type="search" id="searchField" name="search"
+                    autocomplete="off"
+                    autocorrect="off"
+                    autocapitalize="off"
+                    spellcheck="false">
+            </div>
+            <div id="lower">
+                <button id="searchButton">Go search!</button>
+            </div>
+        </div>
+
+        <div id="results">
+        </div>
+
+        <div id="footer">
+            A project for DH2642<br>&copy; 2017
+        </div>
+        <script>
+            var searchContent = ""; // last search string
+            var results = []; // search results
+
+            // grabs the text from the search field and performs a search if necessary and then stages the results
+            function loadResults() {
+                var newSearch = document.getElementById("searchField").value;
+                searchContent = newSearch;
+                if(newSearch != "") {
+                    var xhttp = new XMLHttpRequest();
+                    xhttp.onreadystatechange = function() {
+                        if (this.readyState == 4 && this.status == 200) {
+                            try {
+                                results = JSON.parse(xhttp.responseText).results;
+                                setContent();
+                            } catch (e) {
+                            }
+                        }
+                    };
+                    //xhttp.open("GET", "http://search.considerate.se/?q=" + newSearch, true);
+                    xhttp.open("GET", "http://localhost:3000/search?q=" + newSearch, true);
+                    xhttp.send();
+                }
+                else {
+                    results = [];
+                    setContent();
+                }
+            }
+
+            function getResultBlock(resultNo, name, objects, parameters, returns, link) {
+                string = "";
+                if(objects.length > 0) {
+                    string += "(";
+                    for(var i = 0; i < objects.length; ++i) {
+                        if(i > 0) string += ", ";
+                        string += objects[i][0] + " ";
+                        string += objects[i][1];
+                    }
+                    string += ") ";
+                }
+                string += name;
+                string += "(";
+                if(parameters.length > 0) {
+                    for(var i = 0; i < parameters.length; ++i) {
+                        if(i > 0) string += ", ";
+                        string += parameters[i][0] + " ";
+                        string += parameters[i][1];
+                    }
+                }
+                string += ") ";
+                if(returns.length > 0) {
+                    string += "(";
+                    for(var i = 0; i < returns.length; ++i) {
+                        if(i > 0) string += ", ";
+                        string += returns[i][0] + " ";
+                        string += returns[i][1];
+                    }
+                    string += ") ";
+                }
+                return '<div><p>' + resultNo + '. ' + string + '</p><a href="' + link + '">' + link + '</a></div>';
+            }
+
+            // sets the contents of the search results, if any query has been entered
+            function setContent() {
+                if(searchContent != "") {
+                    document.getElementById("results").innerHTML = "";
+                    res = "";
+                    console.log(results);
+                    for(var i = 0; i < results.length; ++i) {
+                        res += getResultBlock(i, results[i].name || '', results[i].object || [], results[i].parameters || [], results[i].result || [], results[i].uri || '');
+                    }
+                    document.getElementById("results").innerHTML = res;
+                    document.getElementById("results").style.display = "block";
+                    if(results.length === 0) document.getElementById("results").innerHTML = '<p id="error">NO results, please try again...</p>';
+
+                }
+                else document.getElementById("results").style.display = "none";
+            }
+
+            // catch enter keys from search field and click button if one occurs
+            function enterKey(event) {
+                event.preventDefault();
+                if (event.keyCode == 13) {
+                    document.getElementById("searchButton").click();
+                    document.getElementById("searchField").blur();
+                }
+            }
+
+            setContent();
+            document.getElementById("searchButton").addEventListener('click', loadResults);
+            document.getElementById("searchButton").addEventListener('mouseover', function() { this.style.backgroundColor = "#13626c"; });
+            document.getElementById("searchButton").addEventListener('mouseout', function() { this.style.backgroundColor = "#a8e7f0"; });
+            document.getElementById("searchButton").addEventListener('mousedown', function() { this.style.backgroundColor = "black"; });
+            document.getElementById("searchButton").addEventListener('mouseup', function() { this.style.backgroundColor = "#13626c"; });
+            document.getElementById("searchField").addEventListener("keyup", enterKey);
+        </script>
+    </body>
+
 </html>
-		
+

--- a/views/index.html
+++ b/views/index.html
@@ -7,6 +7,7 @@
         <div id="topDiv" style="">
             <div id="upper">
                 <input type="search" id="searchField" name="search"
+                    placeholder="func (r Response) read(String) String"
                     autocomplete="off"
                     autocorrect="off"
                     autocapitalize="off"
@@ -31,25 +32,23 @@
             function loadResults() {
                 var newSearch = document.getElementById("searchField").value;
                 searchContent = newSearch;
-                if(newSearch != "") {
-                    var xhttp = new XMLHttpRequest();
-                    xhttp.onreadystatechange = function() {
-                        if (this.readyState == 4 && this.status == 200) {
-                            try {
-                                results = JSON.parse(xhttp.responseText).results;
-                                setContent();
-                            } catch (e) {
-                            }
+                if(newSearch == "") {
+                    newSearch = document.getElementById('searchField').getAttribute('placeholder');
+                }
+                console.log(newSearch);
+                var xhttp = new XMLHttpRequest();
+                xhttp.onreadystatechange = function() {
+                    if (this.readyState == 4 && this.status == 200) {
+                        try {
+                            results = JSON.parse(xhttp.responseText).results;
+                            setContent();
+                        } catch (e) {
                         }
-                    };
-                    //xhttp.open("GET", "http://search.considerate.se/?q=" + newSearch, true);
-                    xhttp.open("GET", "http://localhost:3000/search?q=" + newSearch, true);
-                    xhttp.send();
-                }
-                else {
-                    results = [];
-                    setContent();
-                }
+                    }
+                };
+                //xhttp.open("GET", "http://search.considerate.se/?q=" + newSearch, true);
+                xhttp.open("GET", "http://localhost:3000/search?q=" + newSearch, true);
+                xhttp.send();
             }
 
             function getResultBlock(resultNo, name, objects, parameters, returns, link) {

--- a/views/index.html
+++ b/views/index.html
@@ -95,8 +95,9 @@
 				if(searchContent != "") {
 					document.getElementById("results").innerHTML = "";
 					res = "";
+					console.log(results);
 					for(var i = 0; i < results.length; ++i) {
-						res += getResultBlock(i, results[i].name, results[i].objects, results[i].arguments, results[i].returns, results[i].link);
+						res += getResultBlock(i, results[i].name || '', results[i].object || [], results[i].parameters || [], results[i].result || [], results[i].uri || '');
 					}
 					document.getElementById("results").innerHTML = res;
 					document.getElementById("results").style.display = "block";

--- a/views/style.css
+++ b/views/style.css
@@ -1,15 +1,14 @@
-
-	body { text-align: center; background-color: #beedf4; overflow-y:scroll }
-	#header {width: 40% }
-	#topDiv {background-color: #6ad7e5; width: 90%; margin: auto; border: 4px solid black; border-radius: 20px}
-	#topDiv div { padding: 20px }
-	#topDiv  #upper { line-height: 40px }
-	#topDiv #lower { padding-top: 0px }
-	#searchField {width: 100%; color: #13626c; font-size: 40px; padding: 5px; height: 70px; border-radius: 10px; background-color: #a8e7f0; border: 2px solid #13626c}
-	#searchButton { cursor: pointer; background-color: #a8e7f0; font-size: 20px; border: 2px solid #13626c; width: 25%; height: 40px; border-radius: 10px }
-	#results { color: #13626c;  background-color: #6ad7e5; width: 90%; padding: 10px 0px; margin: auto; margin-top: 20px; margin-bottom: 20px;  border: 4px solid black; border-radius: 20px }
-	#results div  { border-radius: 10px; background-color: #a8e7f0; border: 2px solid #13626c; padding: 10px; text-align: left; margin: 10px 20px; font-size: 2em }
-	#results div p { margin: 0px; padding: 0px }
-	#results div a { color: #13626c }
-	#footer { font-size: 0.75em; text-align: center; color: #13626c; width: 90%; padding: 10px 0px; margin: auto; margin-top: 20px; margin-bottom: 20px }
-	#error { font-size: 2em; text-align: center}
+body { text-align: center; background-color: #beedf4; overflow-y:scroll }
+#header {width: 40% }
+#topDiv {background-color: #6ad7e5; width: 90%; margin: auto; border: 4px solid black; border-radius: 20px}
+#topDiv div { padding: 20px }
+#topDiv  #upper { line-height: 40px }
+#topDiv #lower { padding-top: 0px }
+#searchField {width: 100%; color: #13626c; font-size: 40px; padding: 5px; height: 70px; border-radius: 10px; background-color: #a8e7f0; border: 2px solid #13626c; -webkit-appearance: none; appearance: none;}
+#searchButton { cursor: pointer; background-color: #a8e7f0; font-size: 20px; border: 2px solid #13626c; width: 25%; height: 40px; border-radius: 10px; -webkit-appearance: none; appearance: none;}
+#results { color: #13626c;  background-color: #6ad7e5; width: 90%; padding: 10px 0px; margin: auto; margin-top: 20px; margin-bottom: 20px;  border: 4px solid black; border-radius: 20px }
+#results div  { border-radius: 10px; background-color: #a8e7f0; border: 2px solid #13626c; padding: 10px; text-align: left; margin: 10px 20px; font-size: 2em }
+#results div p { margin: 0px; padding: 0px }
+#results div a { color: #13626c; font-size: 60% }
+#footer { font-size: 0.75em; text-align: center; color: #13626c; width: 90%; padding: 10px 0px; margin: auto; margin-top: 20px; margin-bottom: 20px }
+#error { font-size: 2em; text-align: center}


### PR DESCRIPTION
Fix issue with spider crashing on large zip files
The issue was due to node-wget always registering a
callback for requestjs causing the library to download
into a in-memory buffer which overflows on too large files.

This is resolved by using request directly and piping to
a fs writestream.